### PR TITLE
fix(blobs): check for keys before rendering

### DIFF
--- a/app/blobs/list.jsx
+++ b/app/blobs/list.jsx
@@ -27,21 +27,24 @@ export function StoredBlobsList({ lastMutationTime }) {
             <div className="text-lg font-bold h-6">Objects in Blob Store</div>
             <div className="flex flex-col gap-1 w-full bg-white text-neutral-900 min-h-56 card">
                 <div className="card-body text-md">
-                    {!keys?.length && <span>Please upload some shapes!</span>}
-                    {keys.map((keyName) => {
-                        const isSelected = keyName === selectedKey;
-                        return (
-                            <div
-                                key={keyName}
-                                onClick={() => {
-                                    onSelect(keyName);
-                                }}
-                                className={'w-full hover:bg-neutral-200 ' + (isSelected ? 'font-bold' : '')}
-                            >
-                                {keyName}
-                            </div>
-                        );
-                    })}
+                    {!keys?.length ? (
+                        <span>Please upload some shapes!</span>
+                    ) : (
+                        keys.map((keyName) => {
+                            const isSelected = keyName === selectedKey;
+                            return (
+                                <div
+                                    key={keyName}
+                                    onClick={() => {
+                                        onSelect(keyName);
+                                    }}
+                                    className={'w-full hover:bg-neutral-200 ' + (isSelected ? 'font-bold' : '')}
+                                >
+                                    {keyName}
+                                </div>
+                            );
+                        })
+                    )}
                     {previewData && <BlobPreview data={previewData} />}
                 </div>
             </div>


### PR DESCRIPTION
There can be a case where keys is undefined, if so the page errors. This fix checks that keys is an array with > 0 elements, and if so renders the blob keys.